### PR TITLE
Set the type of the localize property

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -162,6 +162,7 @@ Polymer.AppLocalizeBehavior = {
      * `localize(stringKey, param1Name, param1Value, param2Name, param2Value)`
      */
     localize: {
+      type: Function,
       computed: '__computeLocalize(language, resources, formats)'
     }
   },


### PR DESCRIPTION
Added the type to the localize property, because if we run polylint on our components we get the following error:
Computed Binding using property 'localize', which is not a function for element

Polylint actually checks the property type and only checks for the methods with the property.type Function
      if (method == property.name) {
        foundMethod = property.type == 'Function';
        foundDefinition = true;
      }