### PR TITLE
Enable pathToRessources property

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -43,11 +43,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 *               language: {
 *                 value: 'en'
 *               },
+*
+*               pathToResources: {
+*                 value: 'locales.json',
+*                 type: String
+*               }
 *             }
 *
-*             attached: function() {
-*               this.loadResources(this.resolveUrl('locales.json'));
-*             },
 *           });
 *        &lt;/script>
 *     </dom-module>
@@ -224,6 +226,12 @@ Polymer.AppLocalizeBehavior = {
 
       return msg.format(args);
     };
+  },
+
+  attached: function() {
+    if (this.pathToResources) {
+      this.loadResources(this.resolveUrl(this.pathToResources));
+    }
   },
 
   __onRequestResponse: function(event) {

--- a/demo/x-translate.html
+++ b/demo/x-translate.html
@@ -73,6 +73,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: String
         },
 
+        pathToResources: {
+          value: 'locales.json',
+          type: String
+        },
+
         /* Overriden from AppLocalizeBehavior */
         formats: {
           type: Object,
@@ -82,10 +87,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             };
           }
         }
-      },
-
-      attached: function() {
-        this.loadResources(this.resolveUrl('locales.json'));
       },
 
       _toggle: function() {


### PR DESCRIPTION
Before this commit, the pathToRessources propert was unused.
Now you can load a dictionary using this property.

Fixes #19