### PR TITLE
Fix missing 'name' from the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sample application loading resources from an external file:
 ```html
 <dom-module id="x-app">
    <template>
-    <div>{{localize('hello', 'Batman')}}</div>
+    <div>{{localize('hello', 'name', 'Batman')}}</div>
    </template>
    <script>
       Polymer({
@@ -59,7 +59,7 @@ Alternatively, you can also inline your resources inside the app itself:
 ```html
 <dom-module id="x-app">
    <template>
-    <div>{{localize('hello', 'Batman')}}</div>
+    <div>{{localize('hello', 'name', 'Batman')}}</div>
    </template>
    <script>
       Polymer({

--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 *
 *     <dom-module id="x-app">
 *        <template>
-*         <div>{{localize('hello', 'Batman')}}</div>
+*         <div>{{localize('hello', 'name', 'Batman')}}</div>
 *        </template>
 *        <script>
 *           Polymer({
@@ -56,7 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 *
 *     <dom-module id="x-app">
 *        <template>
-*         <div>{{localize('hello', 'Batman')}}</div>
+*         <div>{{localize('hello', 'name', 'Batman')}}</div>
 *        </template>
 *        <script>
 *           Polymer({


### PR DESCRIPTION
The example code was not providing the behavior with the actual property name thus resulting in a `Error: A value must be provided for: name(…)`

fixes PolymerElements/app-localize-behavior#14