### PR TITLE
IE10 JavaScript error fix

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -201,7 +201,9 @@ Polymer.AppLocalizeBehavior = {
     var proto = this.constructor.prototype;
 
     // Everytime any of the parameters change, invalidate the strings cache.
-    proto.__localizationCache.messages = {};
+    if (proto.__localizationCache) {
+      proto.__localizationCache.messages = {};
+    }
 
     return function() {
       var key = arguments[0];
@@ -211,11 +213,16 @@ Polymer.AppLocalizeBehavior = {
       // Cache the key/value pairs for the same language, so that we don't
       // do extra work if we're just reusing strings across an application.
       var messageKey = key + resources[language][key];
-      var msg = proto.__localizationCache.messages[messageKey];
+      var msg;
+      if (proto.__localizationCache) {
+        msg = proto.__localizationCache.messages[messageKey];
+      }
 
       if (!msg) {
         msg = new IntlMessageFormat(resources[language][key], language, formats);
-        proto.__localizationCache.messages[messageKey] = msg;
+        if (proto.__localizationCache) {
+          proto.__localizationCache.messages[messageKey] = msg;
+        }
       }
 
       var args = {};


### PR DESCRIPTION
Fixes #29 ("Unable to set property 'messages' of undefined or null reference" JS error) by wrapping access to `__localizationCache` in checks, as it's `undefined` in IE10. This obviously results in no caching goodness for IE10. An alternate approach would be to use a different mechanism than the prototype for storing a singleton cache of values.

I didn't add a test since this really only happens in IE10. If you want to repro, you could likely wire your existing tests up to Sauce with IE10.

Feel free to use a different approach, or just close this and the associated issue outright if you don't care about IE10. Some of us however do need to deal with it for a bit longer, so in the meantime I'll need to work off a fork.
