### PR TITLE
Throw error when a key doesn't exist

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -212,6 +212,10 @@ Polymer.AppLocalizeBehavior = {
       // do extra work if we're just reusing strings across an application.
       var messageKey = key + resources[language][key];
       var msg = proto.__localizationCache.messages[messageKey];
+      
+      if (resources[language][key] === undefined) {
+          throw new Error('Localice key: "' + key + '" in component "' + this.is + '" does not exist.');
+      }
 
       if (!msg) {
         msg = new IntlMessageFormat(resources[language][key], language, formats);


### PR DESCRIPTION
When a key doesn't exist now the behaviour throws a generic error (_Uncaught TypeError: A message must be provided as a String or AST_) and you don't know which key is the one missing.