### PR TITLE
Delete pathToResources property

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -97,15 +97,13 @@ Polymer.AppLocalizeBehavior = {
   },
 
   /**
-   * If the element is using `pathToResources` to load an external resources
-   * file, fired when the file has been loaded.
+   * Fired after the resources have been loaded.
    *
    * @event app-localize-resources-loaded
    */
 
   /**
-   * If the element is using `pathToResources` to load an external resources
-   * file, fired when the file cannot be loaded due to an error.
+   * Fired when the resources cannot be loaded due to an error.
    *
    * @event app-localize-resources-error
    */
@@ -130,16 +128,6 @@ Polymer.AppLocalizeBehavior = {
      */
     resources: {
       type: Object
-    },
-
-    /**
-     * The path to the dictionary of localized messages. The format is the
-     * same as the `resources` array, only saved as an external json file.
-     * Note that using a path will populate the `resources` property, and override
-     * the previous data.
-     */
-    pathToResources: {
-      type: String
     },
 
     /**


### PR DESCRIPTION
pathToRessources is not used, so this property has been deleted.
The documentation for the events fired with this property has been
deleted too.

Fixes #33
