### PR TITLE
Initialize localizationCache if it doesn't exist

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -179,6 +179,11 @@ Polymer.AppLocalizeBehavior = {
   loadResources: function(path) {
     var proto = this.constructor.prototype;
 
+    // In the event proto not have __localizationCache object, create it.
+    if(proto['__localizationCache'] === undefined) {
+      proto['__localizationCache'] = {requests: {}, messages: {}, ajax: null};
+    }
+
     // If the global ajax object has not been initialized, initialize and cache it.
     var ajax = proto.__localizationCache.ajax;
     if (!ajax) {


### PR DESCRIPTION
I'd come across an issue, this.constructor.prototype. __localizationCache is undefined in iOS Safari. (Of cause, it's good in Chrome :-) ) I didn't investigate the root cause of this issue, wrote a check code.