### PR TITLE
Support usage of lang attribute <html lang="fr"> as default language value

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -166,15 +166,19 @@ Polymer.AppLocalizeBehavior = {
     /**
      * If true, the global language attribute on the html tag
      * will be used as the default language value.
+     * Use document.documentElement.lang = "de" to change the language 
+     * of the entire app.
      */
     useHtmlLanguage: {
       type: Boolean,
-      value: false,
-      observer: '__useHtmlLanguageChanged'
+      value: false
     },
 
-    _htmlLanguageObserver: {
-      type: Object
+    /**
+     * The url of the locales.json file
+     */
+    resourceUrl: {
+      type: String
     },
 
     /**
@@ -183,13 +187,26 @@ Polymer.AppLocalizeBehavior = {
     bubbleEvent: {
       type: Boolean,
       value: false
+    },
+
+    /**
+     * The instance of the 'lang' attribute observer 
+     * of the html tag.
+     */
+    ___htmlLanguageObserver: {
+      type: Object
     }
   },
 
+  observers: [
+    '__useHtmlLanguageChanged(useHtmlLanguage)',
+    'loadResources(resourceUrl)'
+  ],
+
   __useHtmlLanguageChanged: function(useHtmlLanguage) {
     if (!useHtmlLanguage) {
-      if (this._htmlLanguageObserver) {
-        this._htmlLanguageObserver.disconnect();
+      if (this.__htmlLanguageObserver) {
+        this.__htmlLanguageObserver.disconnect();
       }
       return;
     }
@@ -199,13 +216,13 @@ Polymer.AppLocalizeBehavior = {
       console.warn('AppLocalizeBehavior needs the lang attribute to be set on the html tag.');
     }
 
-    if (!this._htmlLanguageObserver) {
-      this._htmlLanguageObserver = new MutationObserver(function() {
+    if (!this.__htmlLanguageObserver) {
+      this.__htmlLanguageObserver = new MutationObserver(function() {
         this.language = html.lang;
       }.bind(this));
     }
 
-    this._htmlLanguageObserver.observe(html, { attributes: true });
+    this.__htmlLanguageObserver.observe(html, { attributes: true });
     this.language = html.lang;
   },
 

--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -175,6 +175,16 @@ Polymer.AppLocalizeBehavior = {
     },
 
     /**
+     * If true, the browser language will be used per default.
+     * 'resources' have to include browser language key. 
+     * If not, HtmlLanguage will be used instead.
+     */
+    useBrowserLanguage: {
+      type: Boolean,
+      value: true
+    },
+
+    /**
      * The url of the locales.json file
      */
     resourceUrl: {
@@ -200,8 +210,23 @@ Polymer.AppLocalizeBehavior = {
 
   observers: [
     '__useHtmlLanguageChanged(useHtmlLanguage)',
+    '__useBrowserLanguageChanged(useBrowserLanguage, resources)',
     'loadResources(resourceUrl)'
   ],
+
+  __useBrowserLanguageChanged: function(useBrowserLanguage, resources) {
+    if (!useBrowserLanguage || !resources) {
+      return;
+    }
+
+    if (!this.resources[navigator.language]) {
+      return this.__setHtmlLanguage();
+    }
+
+    if (!this.language) {
+      this.language = navigator.language;
+    }
+  },
 
   __useHtmlLanguageChanged: function(useHtmlLanguage) {
     if (!useHtmlLanguage) {
@@ -211,9 +236,14 @@ Polymer.AppLocalizeBehavior = {
       return;
     }
 
+    this.__setHtmlLanguage();
+  },
+
+  __setHtmlLanguage: function() {
     var html = document.querySelector('html');
     if (html.lang === '') {
       console.warn('AppLocalizeBehavior needs the lang attribute to be set on the html tag.');
+      return;
     }
 
     if (!this.__htmlLanguageObserver) {
@@ -221,8 +251,8 @@ Polymer.AppLocalizeBehavior = {
         this.language = html.lang;
       }.bind(this));
     }
-
     this.__htmlLanguageObserver.observe(html, { attributes: true });
+
     this.language = html.lang;
   },
 

--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -164,12 +164,49 @@ Polymer.AppLocalizeBehavior = {
     },
 
     /**
+     * If true, the global language attribute on the html tag
+     * will be used as the default language value.
+     */
+    useHtmlLanguage: {
+      type: Boolean,
+      value: false,
+      observer: '__useHtmlLanguageChanged'
+    },
+
+    _htmlLanguageObserver: {
+      type: Object
+    },
+
+    /**
     * If true, will bubble up the event to the parents
     */
     bubbleEvent: {
       type: Boolean,
       value: false
     }
+  },
+
+  __useHtmlLanguageChanged: function(useHtmlLanguage) {
+    if (!useHtmlLanguage) {
+      if (this._htmlLanguageObserver) {
+        this._htmlLanguageObserver.disconnect();
+      }
+      return;
+    }
+
+    var html = document.querySelector('html');
+    if (html.lang === '') {
+      console.warn('AppLocalizeBehavior needs the lang attribute to be set on the html tag.');
+    }
+
+    if (!this._htmlLanguageObserver) {
+      this._htmlLanguageObserver = new MutationObserver(function() {
+        this.language = html.lang;
+      }.bind(this));
+    }
+
+    this._htmlLanguageObserver.observe(html, { attributes: true });
+    this.language = html.lang;
   },
 
   loadResources: function(path) {

--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -223,9 +223,7 @@ Polymer.AppLocalizeBehavior = {
       return this.__setHtmlLanguage();
     }
 
-    if (!this.language) {
-      this.language = navigator.language;
-    }
+    this.language = navigator.language;
   },
 
   __useHtmlLanguageChanged: function(useHtmlLanguage) {

--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "paper-toggle-button": "PolymerElements/paper-toggle-button#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
     "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
-    "web-component-tester": "^6.0.0",
+    "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "main": "app-localize-behavior.html",


### PR DESCRIPTION
- `<my-localize-elem use-html-language>` to use the lang attribute of the html tag. (would be cool if defaulted to true)
- `<my-localize-elem resource-url="/src/locals.json">` to auto load resource. (would be cool as well to be defaulted to this.resolveUrl('locales.json'))

Use `document.documentElement.lang = "de"` to change the language within the whole app.

What do you think?