### PR TITLE
New: Add mixin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ dist: trusty
 node_js: stable
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 before_script:
   - npm install -g polymer-cli
   - polymer install --variants

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ dist: trusty
 node_js: stable
 addons:
   firefox: latest
-  chrome: stable
+  apt:
+  sources:
+    - google-chrome
+  packages:
+    - google-chrome-stable
 before_script:
   - npm install -g polymer-cli
   - polymer install --variants

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ node_js: stable
 addons:
   firefox: latest
   apt:
-  sources:
-    - google-chrome
-  packages:
-    - google-chrome-stable
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 before_script:
   - npm install -g polymer-cli
   - polymer install --variants

--- a/app-localize-base.html
+++ b/app-localize-base.html
@@ -1,0 +1,97 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../iron-ajax/iron-ajax.html">
+<link rel="import" href="intl-messageformat-import.html">
+
+<script>
+  (function() {
+    /**
+     * Internal singleton cache. This is the private implementation of the
+     * behaviour; don't interact with it directly.
+     */
+    var __localizationCache = {
+      requests: {},  /* One iron-request per unique resources path. */
+      messages: {},  /* Unique localized strings. Invalidated when the language, formats or resources change. */
+      ajax: null     /* Global iron-ajax object used to request resource files. */
+    };
+
+    Polymer.__appLocalizeBase = {
+      loadResources: function(path) {
+        // If the global ajax object has not been initialized, initialize and cache it.
+        var ajax = __localizationCache.ajax;
+        if (!ajax) {
+          ajax = __localizationCache.ajax = document.createElement('iron-ajax');
+        }
+
+        var request = __localizationCache.requests[path];
+        if (!request) {
+          ajax.url = path;
+          var request = ajax.generateRequest();
+
+          request.completes.then(
+              this.__onRequestResponse.bind(this),
+              this.__onRequestError.bind(this));
+
+          // Cache the instance so that it can be reused if the same path is loaded.
+          __localizationCache.requests[path] = request;
+        } else {
+          request.completes.then(
+              this.__onRequestResponse.bind(this),
+              this.__onRequestError.bind(this));
+        }
+      },
+
+      /**
+       * Returns a computed `localize` method, based on the current `language`.
+       */
+      __computeLocalize: function(language, resources, formats) {
+        return function() {
+          var key = arguments[0];
+          if (!key || !resources || !language || !resources[language])
+            return;
+
+          // Cache the key/value pairs for the same language, so that we don't
+          // do extra work if we're just reusing strings across an application.
+          var translatedValue = resources[language][key];
+
+          if (!translatedValue) {
+            return this.useKeyIfMissing ? key : '';
+          }
+
+          var messageKey = key + translatedValue;
+          var translatedMessage = __localizationCache.messages[messageKey];
+
+          if (!translatedMessage) {
+            translatedMessage = new IntlMessageFormat(translatedValue, language, formats);
+            __localizationCache.messages[messageKey] = translatedMessage;
+          }
+
+          var args = {};
+          for (var i = 1; i < arguments.length; i += 2) {
+            args[arguments[i]] = arguments[i+1];
+          }
+
+          return translatedMessage.format(args);
+        };
+      },
+
+      __onRequestResponse: function(event) {
+        this.resources = event.response;
+        this.fire('app-localize-resources-loaded', event, { bubbles: this.bubbleEvent});
+      },
+
+      __onRequestError: function(event) {
+        this.fire('app-localize-resources-error');
+      }
+    };
+
+  })();
+</script>

--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -9,262 +9,146 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-ajax/iron-ajax.html">
-<script src="../intl-messageformat/dist/intl-messageformat.min.js"></script>
+<link rel="import" href="app-localize-base.html">
 
 <script>
-
-/**
-* `Polymer.AppLocalizeBehavior` wraps the [format.js](http://formatjs.io/) library to
-* help you internationalize your application. Note that if you're on a browser that
-* does not natively support the [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-* object, you must load the polyfill yourself. An example polyfill can
-* be found [here](https://github.com/andyearnshaw/Intl.js/).
-*
-* `Polymer.AppLocalizeBehavior` supports the same [message-syntax](http://formatjs.io/guides/message-syntax/)
-* of format.js, in its entirety; use the library docs as reference for the
-* available message formats and options.
-*
-* Sample application loading resources from an external file:
-*
-*     <dom-module id="x-app">
-*        <template>
-*         <div>{{localize('hello', 'name', 'Batman')}}</div>
-*        </template>
-*        <script>
-*           Polymer({
-*             is: "x-app",
-*
-*             behaviors: [
-*               Polymer.AppLocalizeBehavior
-*             ],
-*
-*             properties: {
-*               language: {
-*                 value: 'en'
-*               },
-*             }
-*
-*             attached: function() {
-*               this.loadResources(this.resolveUrl('locales.json'));
-*             },
-*           });
-*        &lt;/script>
-*     </dom-module>
-*
-* Alternatively, you can also inline your resources inside the app itself:
-*
-*     <dom-module id="x-app">
-*        <template>
-*         <div>{{localize('hello', 'name', 'Batman')}}</div>
-*        </template>
-*        <script>
-*           Polymer({
-*             is: "x-app",
-*
-*             behaviors: [
-*               Polymer.AppLocalizeBehavior
-*             ],
-*
-*             properties: {
-*               language: {
-*                 value: 'en'
-*               },
-*               resources: {
-*                 value: function() {
-*                   return {
-*                     'en': { 'hello': 'My name is {name}.' },
-*                     'fr': { 'hello': 'Je m\'apelle {name}.' }
-*                   }
-*               }
-*             }
-*           });
-*        &lt;/script>
-*     </dom-module>
-*
-* @demo demo/index.html
-* @polymerBehavior Polymer.AppLocalizeBehavior
-*/
-Polymer.AppLocalizeBehavior = {
-  /**
-   * Internal singleton cache. This is the private implementation of the
-   * behaviour; don't interact with it directly.
-   */
-  __localizationCache: {
-    requests: {},  /* One iron-request per unique resources path. */
-    messages: {},  /* Unique localized strings. Invalidated when the language, formats or resources change. */
-    ajax: null     /* Global iron-ajax object used to request resource files. */
-  },
-
-  /**
-   * Fired after the resources have been loaded.
-   *
-   * @event app-localize-resources-loaded
-   */
-
-  /**
-   * Fired when the resources cannot be loaded due to an error.
-   *
-   * @event app-localize-resources-error
-   */
-
-  properties: {
+  (function() {
     /**
-     * The language used for translation.
-     */
-    language: {
-      type: String
-    },
-
-    /**
-     * The dictionary of localized messages, for each of the languages that
-     * are going to be used. See http://formatjs.io/guides/message-syntax/ for
-     * more information on the message syntax.
+     * `Polymer.AppLocalizeBehavior` wraps the [format.js](http://formatjs.io/) library to
+     * help you internationalize your application. Note that if you're on a browser that
+     * does not natively support the [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+     * object, you must load the polyfill yourself. An example polyfill can
+     * be found [here](https://github.com/andyearnshaw/Intl.js/).
      *
-     * For example, a valid dictionary would be:
-     * this.resources = {
-     *  'en': { 'greeting': 'Hello!' }, 'fr' : { 'greeting': 'Bonjour!' }
-     * }
-     */
-    resources: {
-      type: Object
-    },
-
-    /**
-     * Optional dictionary of user defined formats, as explained here:
-     * http://formatjs.io/guides/message-syntax/#custom-formats
+     * `Polymer.AppLocalizeBehavior` supports the same [message-syntax](http://formatjs.io/guides/message-syntax/)
+     * of format.js, in its entirety; use the library docs as reference for the
+     * available message formats and options.
      *
-     * For example, a valid dictionary of formats would be:
-     * this.formats = {
-     *    number: { USD: { style: 'currency', currency: 'USD' } }
-     * }
+     * Sample application loading resources from an external file:
+     *
+     *     <dom-module id="x-app">
+     *        <template>
+     *         <div>{{localize('hello', 'name', 'Batman')}}</div>
+     *        </template>
+     *        <script>
+     *           Polymer({
+     *             is: "x-app",
+     *
+     *             behaviors: [
+     *               Polymer.AppLocalizeBehavior
+     *             ],
+     *
+     *             properties: {
+     *               language: {
+     *                 value: 'en'
+     *               },
+     *             }
+     *
+     *             attached: function() {
+     *               this.loadResources(this.resolveUrl('locales.json'));
+     *             },
+     *           });
+     *        &lt;/script>
+     *     </dom-module>
+     *
+     * Alternatively, you can also inline your resources inside the app itself:
+     *
+     *     <dom-module id="x-app">
+     *        <template>
+     *         <div>{{localize('hello', 'name', 'Batman')}}</div>
+     *        </template>
+     *        <script>
+     *           Polymer({
+     *             is: "x-app",
+     *
+     *             behaviors: [
+     *               Polymer.AppLocalizeBehavior
+     *             ],
+     *
+     *             properties: {
+     *               language: {
+     *                 value: 'en'
+     *               },
+     *               resources: {
+     *                 value: function() {
+     *                   return {
+     *                     'en': { 'hello': 'My name is {name}.' },
+     *                     'fr': { 'hello': 'Je m\'apelle {name}.' }
+     *                   }
+     *               }
+     *             }
+     *           });
+     *        &lt;/script>
+     *     </dom-module>
+     *
+     * @demo demo/index.html
+     * @polymerBehavior Polymer.AppLocalizeBehavior
      */
-    formats: {
-      type: Object,
-      value: function() { return {} }
-    },
+    Polymer.AppLocalizeBehavior = {
+      properties: {
+        /**
+         * The language used for translation.
+         */
+        language: String,
 
-    /**
-     * If true, will use the provided key when
-     * the translation does not exist for that key.
-     */
-    useKeyIfMissing: {
-      type: Boolean,
-      value: false
-    },
+        /**
+         * The dictionary of localized messages, for each of the languages that
+         * are going to be used. See http://formatjs.io/guides/message-syntax/ for
+         * more information on the message syntax.
+         *
+         * For example, a valid dictionary would be:
+         * this.resources = {
+         *  'en': { 'greeting': 'Hello!' }, 'fr' : { 'greeting': 'Bonjour!' }
+         * }
+         */
+        resources: Object,
 
-    /**
-     * Translates a string to the current `language`. Any parameters to the
-     * string should be passed in order, as follows:
-     * `localize(stringKey, param1Name, param1Value, param2Name, param2Value)`
-     */
-    localize: {
-      type: Function,
-      computed: '__computeLocalize(language, resources, formats)'
-    },
+        /**
+         * Optional dictionary of user defined formats, as explained here:
+         * http://formatjs.io/guides/message-syntax/#custom-formats
+         *
+         * For example, a valid dictionary of formats would be:
+         * this.formats = {
+         *    number: { USD: { style: 'currency', currency: 'USD' } }
+         * }
+         */
+        formats: {
+          type: Object,
+          value: function() { return {} }
+        },
 
-    /**
-    * If true, will bubble up the event to the parents
-    */
-    bubbleEvent: {
-      type: Boolean,
-      value: false
-    }
-  },
+        /**
+         * If true, will use the provided key when
+         * the translation does not exist for that key.
+         */
+        useKeyIfMissing: {
+          type: Boolean,
+          value: false
+        },
 
-  loadResources: function(path) {
-    var proto = this.constructor.prototype;
+        /**
+         * Translates a string to the current `language`. Any parameters to the
+         * string should be passed in order, as follows:
+         * `localize(stringKey, param1Name, param1Value, param2Name, param2Value)`
+         */
+        localize: {
+          type: Function,
+          computed: '__computeLocalize(language, resources, formats)'
+        },
 
-    // Check if localCache exist just in case.
-    this.__checkLocalizationCache(proto);
+        /**
+        * If true, will bubble up the event to the parents
+        */
+        bubbleEvent: {
+          type: Boolean,
+          value: false
+        }
+      },
 
-    // If the global ajax object has not been initialized, initialize and cache it.
-    var ajax = proto.__localizationCache.ajax;
-    if (!ajax) {
-      ajax = proto.__localizationCache.ajax = document.createElement('iron-ajax');
-    }
-
-    var request = proto.__localizationCache.requests[path];
-    if (!request) {
-      ajax.url = path;
-      var request = ajax.generateRequest();
-
-      request.completes.then(
-          this.__onRequestResponse.bind(this),
-          this.__onRequestError.bind(this));
-
-      // Cache the instance so that it can be reused if the same path is loaded.
-      proto.__localizationCache.requests[path] = request;
-    } else {
-      request.completes.then(
-          this.__onRequestResponse.bind(this),
-          this.__onRequestError.bind(this));
-    }
-  },
-
-  /**
-   * Returns a computed `localize` method, based on the current `language`.
-   */
-  __computeLocalize: function(language, resources, formats) {
-    var proto = this.constructor.prototype;
-
-    // Check if localCache exist just in case.
-    this.__checkLocalizationCache(proto);
-
-    // Everytime any of the parameters change, invalidate the strings cache.
-    if (!proto.__localizationCache) {
-      proto['__localizationCache'] = {requests: {}, messages: {}, ajax: null};
-    }
-    proto.__localizationCache.messages = {};
-
-    return function() {
-      var key = arguments[0];
-      if (!key || !resources || !language || !resources[language])
-        return;
-
-      // Cache the key/value pairs for the same language, so that we don't
-      // do extra work if we're just reusing strings across an application.
-      var translatedValue = resources[language][key];
-
-      if (!translatedValue) {
-        return this.useKeyIfMissing ? key : '';
-      }
-
-      var messageKey = key + translatedValue;
-      var translatedMessage = proto.__localizationCache.messages[messageKey];
-
-      if (!translatedMessage) {
-        translatedMessage = new IntlMessageFormat(translatedValue, language, formats);
-        proto.__localizationCache.messages[messageKey] = translatedMessage;
-      }
-
-      var args = {};
-      for (var i = 1; i < arguments.length; i += 2) {
-        args[arguments[i]] = arguments[i+1];
-      }
-
-      return translatedMessage.format(args);
+      loadResources: Polymer.__appLocalizeBase.loadResources,
+      __computeLocalize: Polymer.__appLocalizeBase.__computeLocalize,
+      __onRequestResponse: Polymer.__appLocalizeBase.__onRequestResponse,
+      __onRequestError: Polymer.__appLocalizeBase.__onRequestError,
     };
-  },
-
-  __onRequestResponse: function(event) {
-    this.resources = event.response;
-    this.fire('app-localize-resources-loaded', event, { bubbles: this.bubbleEvent});
-  },
-
-  __onRequestError: function(event) {
-    this.fire('app-localize-resources-error');
-  },
-
-  __checkLocalizationCache: function(proto) {
-    // do nothing if proto is undefined.
-    if(proto === undefined) return;
-
-    // In the event proto not have __localizationCache object, create it.
-    if(proto['__localizationCache'] === undefined) {
-      proto['__localizationCache'] = {requests: {}, messages: {}, ajax: null};
-    }
-  }
-}
-
+  })();
 </script>

--- a/app-localize-mixin.html
+++ b/app-localize-mixin.html
@@ -1,0 +1,165 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="app-localize-base.html">
+
+<script>
+  (() => {
+    /**
+     * `Polymer.AppLocalizeMixin` wraps the [format.js](http://formatjs.io/) library to
+     * help you internationalize your application. Note that if you're on a browser that
+     * does not natively support the [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+     * object, you must load the polyfill yourself. An example polyfill can
+     * be found [here](https://github.com/andyearnshaw/Intl.js/).
+     *
+     * `Polymer.AppLocalizeMixin` supports the same [message-syntax](http://formatjs.io/guides/message-syntax/)
+     * of format.js, in its entirety; use the library docs as reference for the
+     * available message formats and options.
+     *
+     * Sample application loading resources from an external file:
+     *
+     *     <dom-module id="x-app">
+     *        <template>
+     *         <div>{{localize('hello', 'name', 'Batman')}}</div>
+     *        </template>
+     *        <script>
+     *           class XApp extends Polymer.AppLocalizeMixin(Polymer.Element) {
+     *             static get is() { return 'x-app' }
+     *
+     *             static get properties() {
+     *               return {
+     *                 language: {
+     *                   type: String,
+     *                   value: 'en',
+     *                 },
+     *               };
+     *             }
+     *
+     *             connectedCallback() {
+     *               super.connectedCallback();
+     *               this.loadResources(this.resolveUrl('locales.json'));
+     *             }
+     *           }
+     *           customElements.define(XApp.is, XApp);
+     *        &lt;/script>
+     *     </dom-module>
+     *
+     * Alternatively, you can also inline your resources inside the app itself:
+     *
+     *     <dom-module id="x-app">
+     *        <template>
+     *         <div>{{localize('hello', 'name', 'Batman')}}</div>
+     *        </template>
+     *        <script>
+     *           class XApp extends Polymer.AppLocalizeMixin(Polymer.Element) {
+     *             static get is() { return 'x-app' }
+     *
+     *             static get properties() {
+     *               return {
+     *                 language: {
+     *                   type: String,
+     *                   value: 'en',
+     *                 },
+     *                 resources: {
+     *                   type: Object,
+     *                   value() {
+     *                     return {
+     *                       en: { hello: 'My name is {name}.' },
+     *                       fr: { hello: 'Je m\'apelle {name}.' },
+     *                     };
+     *                   }
+     *                 },
+     *               };
+     *             }
+     *           }
+     *           customElements.define(XApp.is, XApp);
+     *        &lt;/script>
+     *     </dom-module>
+     *
+     * @demo demo/index.html
+     * @polymerMixin
+     */
+    Polymer.AppLocalizeMixin = (baseClass) => {
+      return class extends baseClass {
+        static get properties() {
+          return {
+            /**
+             * The language used for translation.
+             */
+            language: String,
+
+            /**
+             * The dictionary of localized messages, for each of the languages that
+             * are going to be used. See http://formatjs.io/guides/message-syntax/ for
+             * more information on the message syntax.
+             *
+             * For example, a valid dictionary would be:
+             * this.resources = {
+             *  'en': { 'greeting': 'Hello!' }, 'fr' : { 'greeting': 'Bonjour!' }
+             * }
+             */
+            resources: Object,
+
+            /**
+             * Optional dictionary of user defined formats, as explained here:
+             * http://formatjs.io/guides/message-syntax/#custom-formats
+             *
+             * For example, a valid dictionary of formats would be:
+             * this.formats = {
+             *    number: { USD: { style: 'currency', currency: 'USD' } }
+             * }
+             */
+            formats: {
+              type: Object,
+              value() { return {} }
+            },
+
+            /**
+             * If true, will use the provided key when
+             * the translation does not exist for that key.
+             */
+            useKeyIfMissing: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * Translates a string to the current `language`. Any parameters to the
+             * string should be passed in order, as follows:
+             * `localize(stringKey, param1Name, param1Value, param2Name, param2Value)`
+             */
+            localize: {
+              type: Function,
+              computed: '__computeLocalize(language, resources, formats)'
+            },
+
+            /**
+            * If true, will bubble up the event to the parents
+            */
+            bubbleEvent: {
+              type: Boolean,
+              value: false
+            }
+          };
+        }
+
+        constructor() {
+          super();
+
+          this.loadResources = Polymer.__appLocalizeBase.loadResources;
+          this.__computeLocalize = Polymer.__appLocalizeBase.__computeLocalize;
+          this.__onRequestResponse = Polymer.__appLocalizeBase.__onRequestResponse;
+          this.__onRequestError = Polymer.__appLocalizeBase.__onRequestError;
+        }
+      };
+    };
+  })();
+</script>

--- a/bower.json
+++ b/bower.json
@@ -31,8 +31,7 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "paper-toggle-button": "PolymerElements/paper-toggle-button#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "main": "app-localize-behavior.html",

--- a/intl-messageformat-import.html
+++ b/intl-messageformat-import.html
@@ -1,0 +1,1 @@
+<script src="../intl-messageformat/dist/intl-messageformat.min.js"></script>


### PR DESCRIPTION
A bit of a hacky consolidation but is a similar approach to how I handled it in lazy-imports. 

Base and Behavior are still ES5
Mixin is ES6

- Cleaned up some of the local cache similarly to how it is is handled in lazy-imports.
- Moved external dependency to a separate html import
- Bumped WCT to 6 on the mainline

Things to do if we decide to move forward: 
- [ ] Tests
- [ ] Demos
- [ ] Documentation
- [ ] Linting to ensure no ES6 leaks into the Base or Behavior

@notwaldorf @e111077 