### PR TITLE
add optional preprocessor param to loadResources

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -52,6 +52,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 *        &lt;/script>
 *     </dom-module>
 *
+*
+* If the resources stored in your external file are in a different
+* format, you can pass `loadResources` an optional second parameter, a
+* preprocessing function to be called on the loaded data before setting
+* `resources` to the result. For example:
+*
+*     attached: function() {
+*       this.loadResources(
+*
+*         // Only contains the flattened "es" translations:
+*         'locales/es.json',  // {"hi": "hola", "bye": "chau"}
+*
+*         function preprocess(resources) {
+*           return {es: resources};  // unflatten: {"es": {"hi": "hola", ...}}
+*         }
+*       );
+*     }
+*
+*
 * Alternatively, you can also inline your resources inside the app itself:
 *
 *     <dom-module id="x-app">
@@ -172,7 +191,7 @@ Polymer.AppLocalizeBehavior = {
     }
   },
 
-  loadResources: function(path) {
+  loadResources: function(path, preprocessor) {
     var proto = this.constructor.prototype;
 
     // Check if localCache exist just in case.
@@ -185,19 +204,24 @@ Polymer.AppLocalizeBehavior = {
     }
 
     var request = proto.__localizationCache.requests[path];
+
+    function onRequestResponse(event) {
+      this.__onRequestResponse(event, preprocessor);
+    }
+
     if (!request) {
       ajax.url = path;
       var request = ajax.generateRequest();
 
       request.completes.then(
-          this.__onRequestResponse.bind(this),
+          onRequestResponse.bind(this),
           this.__onRequestError.bind(this));
 
       // Cache the instance so that it can be reused if the same path is loaded.
       proto.__localizationCache.requests[path] = request;
     } else {
       request.completes.then(
-          this.__onRequestResponse.bind(this),
+          onRequestResponse.bind(this),
           this.__onRequestError.bind(this));
     }
   },
@@ -247,8 +271,8 @@ Polymer.AppLocalizeBehavior = {
     };
   },
 
-  __onRequestResponse: function(event) {
-    this.resources = event.response;
+  __onRequestResponse: function(event, preprocessor) {
+    this.resources = preprocessor ? preprocessor(event.response) : event.response;
     this.fire('app-localize-resources-loaded', event, { bubbles: this.bubbleEvent});
   },
 


### PR DESCRIPTION
Hey again,

We had another core localization need that other users might share, so here goes another PR, in case it's helpful!

This change adds an optional second parameter to `loadResources`, a `preprocessor` function, which if supplied, will be called on the loaded data before assigning it to `resources`.

I think this fixes #75 and #103.

#### Background
My team will be using [Transifex](https://www.transifex.com) for managing our translations. (If you're working on an Internet freedom project and trying to make it accessible to as many users as possible, Transifex is [the place to be](https://www.transifex.com/otf/public/).)

Transifex [expects](https://docs.transifex.com/client/client-configuration#-tx/config) you to keep your resources for each language in a separate file of flat messages, so like:
```
./locales/
  ├── en.json    // {"hi": "hi"}
  └── es.json    // {"hi": "hola"}
```
In contrast, `AppLocalizeBehavior` expects you to store resources for a given language nested inside the key for that language, e.g. `{"es": {"hi": "hola"}}`.

Since our translation platform doesn't support that format, we currently resort to calling `loadResources` to fetch our flattened resources for the currently-needed language, resulting in `resources` temporarily getting set to data in the wrong format. Then we have an observer that notices when `resources` has changed, checks if the data is in the flattened/wrong format, and if so, sets `resources` to the expected format. Which is unfortunately convoluted and less efficient.

Being able to pass an optional `preprocessor` function to `loadResources` would allow us to get the fetched data into the right format from the get-go:

```javascript
attached: function() {
  this.loadResources(

    // Only contains the flattened "es" translations:
    'locales/es.json',  // {"hi": "hola"}

    function preprocess(resources) {
      return {es: resources};  // unflatten -> {"es": {"hi": "hola"}}
    }
  );
}
```

It also adds a bit more flexibility to support other formats, as long as a `preprocessor` function can be supplied that returns the data in the format that `AppLocalizeBehavior` is expecting.

If there is interest in adding support for this, and this PR is on the right track, I'm happy to put any further work into it to get it into a mergeable state!

Thanks for your consideration, and thanks again for the great work on Polymer!