### PR TITLE
Add namespace multi level on translation ressources

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -160,6 +160,11 @@ Polymer.AppLocalizeBehavior = {
      * this.resources = {
      *  'en': { 'greeting': 'Hello!' }, 'fr' : { 'greeting': 'Bonjour!' }
      * }
+     * With namespace multi level :
+     this.resources = {
+     *  'en': { 'login': {'greeting': 'Hello!' }}, 'fr' : { 'login': {'greeting': 'Bonjour!' }}
+     * }
+     * use with ":" separator eg : localize('login:greeting')
      */
     resources: {
       type: Object
@@ -264,7 +269,16 @@ Polymer.AppLocalizeBehavior = {
 
       // Cache the key/value pairs for the same language, so that we don't
       // do extra work if we're just reusing strings across an application.
-      var translatedValue = resources[language][key];
+      var subKey = key.split(":");
+      if (subKey.length > 1) {
+        // use namesSpace multi level
+        var translatedValue = resources[language][subKey[0]];
+        for (var i=1; i<subKey.length; i++) {
+            translatedValue = translatedValue[subKey[i]];
+        }
+      } else {
+        var translatedValue = resources[language][key];
+      }
 
       if (!translatedValue) {
         return this.useKeyIfMissing ? key : '';


### PR DESCRIPTION
Could use with :

'mynamespace': {
   'my-key1' : 'foo1',
   'my-key2' : 'foo2'
   },
'foonamespace': {
    'level2' : {
       'my-key1' : 'toto1',
       'my_key2' : 'titi2'
     }
  }
get translation : localize('foonamespace:level2:my-key1')