### PR TITLE
Add fallback language for localization

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -152,6 +152,21 @@ Polymer.AppLocalizeBehavior = {
     },
 
     /**
+     * Fallback Language if the current language is not yet translated.
+     *
+     * For example having only english translation, but trying to open a french localization will return the fallback language
+     *
+     * this.resources = {
+     *  'en': { 'greeting': 'Hello!' }
+     * }
+     *
+     *
+     */
+    fallbackLanguage:{
+        type: String
+    },
+
+    /**
      * The dictionary of localized messages, for each of the languages that
      * are going to be used. See http://formatjs.io/guides/message-syntax/ for
      * more information on the message syntax.
@@ -195,7 +210,7 @@ Polymer.AppLocalizeBehavior = {
      */
     localize: {
       type: Function,
-      computed: '__computeLocalize(language, resources, formats)'
+      computed: '__computeLocalize(language, fallbackLanguage, resources, formats)'
     },
 
     /**
@@ -245,7 +260,7 @@ Polymer.AppLocalizeBehavior = {
   /**
    * Returns a computed `localize` method, based on the current `language`.
    */
-  __computeLocalize: function(language, resources, formats) {
+  __computeLocalize: function(language, fallbackLanguage, resources, formats) {
     var proto = this.constructor.prototype;
 
     // Check if localCache exist just in case.
@@ -262,9 +277,14 @@ Polymer.AppLocalizeBehavior = {
       if (!key || !resources || !language || !resources[language])
         return;
 
+
       // Cache the key/value pairs for the same language, so that we don't
       // do extra work if we're just reusing strings across an application.
       var translatedValue = resources[language][key];
+      //use fallback key if provided
+      if(!translatedValue && fallbackLanguage){
+          translatedValue = resources[fallbackLanguage][key];
+      }
 
       if (!translatedValue) {
         return this.useKeyIfMissing ? key : '';

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../../paper-styles/typography.html">
     <link rel="import" href="x-translate.html">
+    <link rel="import" href="x-fallback.html">
     <link rel="import" href="x-local-translate.html">
 
     <!-- Intl polyfill -->
@@ -30,5 +31,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body unresolved>
     <x-translate use-key-if-missing></x-translate>
     <x-local-translate></x-local-translate>
+    <x-fallback></x-fallback>
   </body>
 </html>

--- a/demo/locales.json
+++ b/demo/locales.json
@@ -7,7 +7,8 @@
     "cats": "I have {numCats, number} cats. Almost {pctBlack, number, percent} of them are black.",
     "sale": "Sale begins {start, date, medium}, at {time, time, short}. Everything is {price, number, USD}.",
     "fruit": "{num, plural, =0 {no apples} =1 {one apple} other {# apples}}",
-    "bananas": "{name} ate {num, plural, =0 {no bananas} =1 {a banana} other {# bananas}} {gender, select, male {at his house.} female {at her house.} other {at their house.}}"
+    "bananas": "{name} ate {num, plural, =0 {no bananas} =1 {a banana} other {# bananas}} {gender, select, male {at his house.} female {at her house.} other {at their house.}}",
+    "missing_translation": "Hello world!"
   },
   "fr": {
     "header_1": "Traduction et localisation",
@@ -18,5 +19,8 @@
     "sale": "La vente commence le {start, date, medium} à {time, time, short}. Tout est à {price, number, USD}.",
     "fruit": "{num, plural, =0 {pas de pommes} =1 {une pomme} other {# pommes}}",
     "bananas": "{name} {num, plural, =0 {ne} =1 {} other {}} mange {num, plural, =0 {pas de bananes} =1 {une banane} other {# bananes}} {gender, select, male {chez lui.} female {chez elle.} other {chez eux.}}"
+  },
+  "en_US": {
+    "missing_translation": "Default fallback language"
   }
 }

--- a/demo/x-fallback.html
+++ b/demo/x-fallback.html
@@ -1,0 +1,71 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../paper-toggle-button/paper-toggle-button.html">
+<link rel="import" href="../app-localize-behavior.html">
+<link rel="import" href="common-styles.html">
+
+<dom-module id="x-fallback">
+  <template>
+    <style include="common-styles"></style>
+
+    <div class="lang">
+      <span title="english">🇬🇧 EN</span>
+      <paper-toggle-button on-change="_toggle" id="switch"></paper-toggle-button>
+      <span title="french">FR 🇫🇷</span>
+    </div>
+
+    <h4>This will fallback from FR to en_US and use this language, because there is no missing_translation key in french and fallbackLanguage is set to en_US</h4>
+    <div class="snippet">
+      <div class="demo">
+
+        <div>{{localize('missing_translation')}}</div>
+      </div>
+      <div class="code-container">
+        <code>localize('missing_translation')
+        </code>
+      </div>
+    </div>
+
+  </template>
+
+
+
+  <script>
+    Polymer({
+      is: "x-fallback",
+
+      behaviors: [
+        Polymer.AppLocalizeBehavior
+      ],
+
+      properties: {
+        /* Overriden from AppLocalizeBehavior */
+        language: {
+          value: 'en',
+          type: String
+        },
+        fallbackLanguage: {
+          value: 'en_US',
+          type: String
+        }
+      },
+
+      attached: function() {
+        this.loadResources(this.resolveUrl('locales.json'));
+      },
+
+      _toggle: function() {
+        this.language = this.$.switch.checked ? 'fr' : 'en';
+      }
+    });
+  </script>
+</dom-module>

--- a/demo/x-translate.html
+++ b/demo/x-translate.html
@@ -34,6 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
       <div class="code-container">
         <code>localize('greeting')</code>
+        <code>localize('missing_translation')</code>
         <code>localize('intro', 'name', 'Batman')</code>
         <code>localize('cats', 'numCats', 10000, 'pctBlack', 0.42)</code>
         <!-- Dates need to be a valid JavaScript object. For an example, we

--- a/test/basic.html
+++ b/test/basic.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../intl/locale-data/jsonp/fr.js"></script>
 
   <link rel="import" href="x-translate.html">
+  <link rel="import" href="x-translate-fallback.html">
   <link rel="import" href="x-translate2.html">
   <link rel="import" href="x-translate-only-imperative.html">
   <link rel="import" href="x-translate-l10n.html">
@@ -36,6 +37,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="basic">
     <template>
       <x-translate></x-translate>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="fallback">
+    <template>
+      <x-translate-fallback></x-translate-fallback>
     </template>
   </test-fixture>
 
@@ -87,6 +94,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     suite('basic', function() {
+        test('uses fallback language, if translation is missing', function() {
+            var app = fixture('fallback');
+            assert.equal(app.language, 'fr');
+            assert.equal(app.fallbackLanguage, 'en');
+            assert.equal(app.$.fallback.innerHTML, 'français hello');
+
+        });
+
+
+
       test('can translate a basic string', function() {
         var app = fixture('basic');
 
@@ -98,6 +115,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(app.language, 'fr');
         assert.equal(app.$.output.innerHTML, 'bonjour');
       });
+
+
+
 
       test('can handle missing keys', function() {
         var app = fixture('missing');

--- a/test/x-translate-fallback.html
+++ b/test/x-translate-fallback.html
@@ -1,0 +1,53 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../app-localize-behavior.html">
+
+<dom-module id="x-translate-fallback">
+    <template>
+        <div id="fallback">{{localize('language')}} {{localize('greeting')}}</div>
+    </template>
+
+    <script>
+        Polymer({
+            is: "x-translate-fallback",
+
+            behaviors: [
+                Polymer.AppLocalizeBehavior
+            ],
+
+            properties: {
+                language: {
+                    value: 'fr',
+                    type: String
+                },
+                fallbackLanguage: {
+                    value: "en",
+                    type: String
+                },
+                resources: {
+                    type: Object,
+                    value: function () {
+                        return {
+                            'en': {
+                                'language': "english",
+                                'greeting': 'hello'
+                            },
+                            'fr': {
+                                'language':"français"
+                            }
+                        };
+                    }
+                }
+            }
+        });
+    </script>
+</dom-module>


### PR DESCRIPTION
This fixes #116 by adding a fallbackLanguage in case the currently used one has no translation for the used localization. 
