### PR TITLE
Returns the key if there is no matching locale and useKeyIfMissing is…

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -260,7 +260,7 @@ Polymer.AppLocalizeBehavior = {
     return function() {
       var key = arguments[0];
       if (!key || !resources || !language || !resources[language])
-        return;
+        return (key && this.useKeyIfMissing) ? key : undefined;
 
       // Cache the key/value pairs for the same language, so that we don't
       // do extra work if we're just reusing strings across an application.

--- a/test/basic.html
+++ b/test/basic.html
@@ -69,6 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="missing-locale">
+    <template>
+      <x-translate use-key-if-missing></x-translate>
+    </template>
+  </test-fixture>
   <script>
     function getRequestsCache(elem) {
       return elem.constructor.prototype.__localizationCache.requests;
@@ -166,6 +171,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         app.language = 'fake';
 
         assert.equal(app.localize('greeting'), undefined);
+      });
+
+      test('can handle missing keys and missing locale', function() {
+        var app = fixture('missing-locale');
+
+        assert.equal(app.language, 'en');
+        assert.equal(app.$.missing.innerHTML, 'missing');
+
+        app.language = 'bg';
+        assert.equal(app.language, 'bg');
+        assert.equal(app.$.missing.innerHTML, 'missing');
       });
     });
 


### PR DESCRIPTION
… enabled

Fixes #123 by a simple check for the presence of a `key` and `useKeyIfMissing` set to `true`.