### PR TITLE
Fix tests on older chrome, which returns different values for `Intl.NumberFormat#format` with currency.

### DIFF
--- a/test/x-translate-l10n.js
+++ b/test/x-translate-l10n.js
@@ -29,7 +29,11 @@ Polymer({
     formats: {
       type: Object,
       value: function() {
-        return {number: {USD: {style: 'currency', currency: 'USD'}}};
+        return {
+          number: {
+            USD: {style: 'currency', currency: 'USD', minimumFractionDigits: 2}
+          }
+        };
       }
     },
     resources: {


### PR DESCRIPTION
Chrome 41 requires `minimumFractionDigits`:
```js
formatter = new Intl.NumberFormat('fr-FR', {
  style: 'currency',
  currency: 'USD',
});
formatter.format(10); // returns "10 $US"

formatter = new Intl.NumberFormat('fr-FR', {
  style: 'currency',
  currency: 'USD',
  minimumFractionDigits: 2,
});
formatter.format(10); // returns "10,00 $US"
```